### PR TITLE
Use Kafka image under the Confluent Community License

### DIFF
--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-server:7.3.0
+    image: confluentinc/cp-kafka:7.3.0
     hostname: broker
     container_name: broker
     depends_on:
@@ -25,7 +25,6 @@ services:
       KAFKA_ZOOKEEPER_CONNECT: 'zookeeper:2181'
       KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
       KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://broker:29092,PLAINTEXT_HOST://localhost:9092
-      KAFKA_METRIC_REPORTERS: io.confluent.metrics.reporter.ConfluentMetricsReporter
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
       KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
       KAFKA_CONFLUENT_LICENSE_TOPIC_REPLICATION_FACTOR: 1
@@ -34,16 +33,14 @@ services:
       KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
       KAFKA_JMX_PORT: 9101
       KAFKA_JMX_HOSTNAME: localhost
-      KAFKA_CONFLUENT_SCHEMA_REGISTRY_URL: http://schema-registry:8081
-      CONFLUENT_METRICS_REPORTER_BOOTSTRAP_SERVERS: broker:29092
-      CONFLUENT_METRICS_REPORTER_TOPIC_REPLICAS: 1
-      CONFLUENT_METRICS_ENABLE: 'true'
-      CONFLUENT_SUPPORT_CUSTOMER_ID: 'anonymous'
 
   kafka-connect:
-    image: yitaekhwang/cp-kafka-connect-questdb:7.3.0-1
+    image: cp-kafka-connect-questdb
     hostname: connect
     container_name: connect
+    build:  
+      context: ./../docker
+      dockerfile: ./Dockerfile
     depends_on:
       - broker
       - zookeeper

--- a/docker-compose/questdb-sink-btc.json
+++ b/docker-compose/questdb-sink-btc.json
@@ -9,6 +9,7 @@
     "key.converter.schemas.enable": "false",
     "value.converter.schemas.enable": "false",
     "host": "questdb",
-    "timestamp.field.name": "timestamp"
+    "timestamp.field.name": "timestamp",
+    "symbols":"currency"
   }
 }


### PR DESCRIPTION
The original image used Confluent Platform which is released under Confluent Commercial license.

Also: Switching from Kafka Connect image on DockerHub to a locally build image. So it will work on both Intel and ARM architectures. (the image is published only for ARM on DockerHub)